### PR TITLE
Add masterPower config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Due to HomeKit app limitation max. services for 1 accessory is 100. Over this va
 `ZST ON, ZST OFF`
 7. In `refreshInterval` set the data refresh time in seconds, default 5sec.
 8. In `zoneControl` You can select which zone U want to control.
+8. If `masterPower` is `true` the power switch for that zone (typically you would only use this for the Main Zone)
+will turn the entire receiver `ON` or `OFF/STANDBY` rather than just the zone itself.
 9. In `volumeControl` You can select what a additional volume control mode You want to use (None, Slider, Fan).
 10. If `switchInfoMenu` is enabled, `I` button toggle its behaviour in RC app and `PowerModeSelection` in settings.
 11. All possible commands can be found in [Denon Control Protocol 2020](http://assets.denon.com/_layouts/15/xlviewer.aspx?id=/DocumentMaster/us/DENON_FY20%20AVR_PROTOCOL_V03_03042020.xlsx)

--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ class denonTvDevice {
 		this.port = config.port;
 		this.refreshInterval = config.refreshInterval || 5;
 		this.zoneControl = config.zoneControl;
+		this.masterPower = config.masterPower;
 		this.volumeControl = config.volumeControl;
 		this.switchInfoMenu = config.switchInfoMenu;
 		this.inputs = config.inputs;
@@ -480,11 +481,13 @@ class denonTvDevice {
 	async setPower(state, callback) {
 		var me = this;
 		let powerState = me.currentPowerState;
-		let newState = [(powerState ? 'ZMOFF' : 'ZMON'), (powerState ? 'Z2OFF' : 'Z2ON'), (powerState ? 'Z3OFF' : 'Z3ON'), (powerState ? 'PWSTANDBY' : 'PWON')][me.zoneControl];
+		const zControl = me.masterPower? 3 : me.zoneControl
+		me.log.debug('zControl is %s', zControl)
+		let newState = [(powerState ? 'ZMOFF' : 'ZMON'), (powerState ? 'Z2OFF' : 'Z2ON'), (powerState ? 'Z3OFF' : 'Z3ON'), (powerState ? 'PWSTANDBY' : 'PWON')][zControl];
 		if ((state && !powerState) || (!state && powerState)) {
 			try {
 				const response = await axios.get(me.url + '/goform/formiPhoneAppDirect.xml?' + newState);
-				me.log.info('Device: %s %s %s, set new Power state successful: %s', me.host, me.name, me.zoneName, state ? 'ON' : 'OFF');
+				me.log.info('Device: %s %s %s, set new Power state successful: %s', me.host, me.name, me.zoneName, newState );
 				callback(null);
 			} catch (error) {
 				me.log.error('Device: %s %s %s, can not set new Power state. Might be due to a wrong settings in config, error: %s', me.host, me.name, me.zoneName, error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-denon-tv",
-  "version": "3.3.32",
+  "version": "3.3.33",
   "description": "Homebridge plugin (https://github.com/homebridge/homebridge) to control Denon/Marantz AV Receivers series X.",
   "license": "MIT",
   "author": "grzegorz914",


### PR DESCRIPTION
In my setup I want the Main Zone power button to turn the power on or (standby/off) for the entire receiver, not just the main zone itself. I added a `masterPower` config option to enable that behavior.