### PR TITLE
Small improvements for Config UI X experience

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -80,7 +80,7 @@
                   ]
                 },
                 {
-                  "title": "Slider",
+                  "title": "Lightbulb",
                   "enum": [
                     1
                   ]

--- a/config.schema.json
+++ b/config.schema.json
@@ -119,6 +119,12 @@
               "title": "Info Button",
               "type": "string",
               "oneOf": [{
+                  "title": "MENU",
+                  "enum": [
+                    "MNMEN ON"
+                  ]
+                },
+                {
                   "title": "OPTION",
                   "enum": [
                     "MNOPT"


### PR DESCRIPTION
This PR contains two small changes: 

1. Add "menu" as an option for configuring the RC info button. The menu button opens up the full menu for my Denon receiver where I can configure all the options. User can click the info button on the RC to change whatever they want and use the back button to get out of it. I've validated this change myself, it works, so I think it should be added as an option for Config UI X users. 
2. Change "slider" to "lightbulb" in the volume control accessory type dropdown. This clarifies the actual type of accessory that it uses. I feel this is important in one scenario: if user tries to say "turn off all lights in the living room" they wouldn't want the volume to be muted. With the clarification they can choose "fan" as the option more directly. 

Great plug-in by the way!