### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v8
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/grzegorz914/homebridge-denon-tv/security/code-scanning/1](https://github.com/grzegorz914/homebridge-denon-tv/security/code-scanning/1)

In general, the fix is to explicitly declare GITHUB_TOKEN permissions in the workflow, granting only what this job needs. For the stale bot, this means allowing write access to issues and pull requests, and typically read-only access to repository contents. This replaces any reliance on potentially broad repository-level defaults.

The best targeted fix here is to add a `permissions` block to the `stale` job in `.github/workflows/stale.yml`, right under `runs-on: ubuntu-latest`. Based on the CodeQL suggestion and the behavior of `actions/stale`, the job should have: `contents: write` (to cover any repository-content operations if needed; CodeQL recommends write here), `issues: write` (to label, comment on, and close issues), and `pull-requests: write` (to label, comment on, and close PRs). No other permissions are required by the workflow as shown. No new imports or other code changes are needed; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
